### PR TITLE
Fix filesystem path URIs

### DIFF
--- a/options.js
+++ b/options.js
@@ -31,7 +31,7 @@ const findRecursive = async (dir, fileName, root) => {
   let result;
 
   try {
-    await vscode.workspace.fs.stat(fullPath);
+    await vscode.workspace.fs.stat(vscode.Uri.file(fullPath));
     result = fullPath;
   } catch {
     result = null;
@@ -155,7 +155,7 @@ module.exports = async (doc, type, formattingOptions) => {
         else configFile = path.resolve(root, beautify_config);
 
         try {
-          await vscode.workspace.fs.stat(configFile)
+          await vscode.workspace.fs.stat(vscode.Uri.file(configFile))
         } catch {
           configFile = null;
         }
@@ -169,14 +169,14 @@ module.exports = async (doc, type, formattingOptions) => {
     configFile = path.join(os.homedir(), '.jsbeautifyrc');
 
     try {
-      await vscode.workspace.fs.stat(configFile)
+      await vscode.workspace.fs.stat(vscode.Uri.file(configFile))
     } catch {
       return Promise.resolve(opts);
     }
   }
   return new Promise((resolve, reject) => {
-    return vscode.workspace.fs.readFile(configFile).then(d => {
-      if(!d || !d.length) return resolve(opts);
+    return vscode.workspace.fs.readFile(vscode.Uri.file(configFile)).then(d => {
+      if (!d || !d.length) return resolve(opts);
       try {
         const unCommented = dropComments(d.toString());
         opts = JSON.parse(unCommented);


### PR DESCRIPTION
## ✨ Pull Request

<!-- Fill the following checklist. -->
- [x] Used a clear / meaningful title for this pull request.
- [x] Tested the changes in your editor (with your configurations).
- [x] Added / Edited tests to reflect changes (`test` folder).
- [x] Have read the **CONTRIBUTING.md** document.
- [x] Passed `npm test`.
- [x] I noted my changes in the pull request body and/or changelog.

#### 🔧 Fixes

https://github.com/vsce-toolroom/vscode-beautify/issues/2

#### Description

Paths for filesystem calls need to be converted to URIs or it fails to find and load the .jsbeatuifyrc file.

#### What changes have you made?

- Paths are converted to URIs for filesytem calls

#### What tests have you completed?

- [ ] Tested this in Visual Studio Code v.
- [ ] Tested this in Visual Studio Code Insiders v.
- [ ] Tested this in GitHub Codespaces v.
- [ ] Tested this in VSCodium v.

